### PR TITLE
fixed fatal error in validator

### DIFF
--- a/src/Frozennode/Administrator/Validator.php
+++ b/src/Frozennode/Administrator/Validator.php
@@ -197,7 +197,7 @@ class Validator extends \Illuminate\Validation\Validator {
 	/**
 	 * Validate that an attribute is a string.
 	 */
-	protected function validateString($attribute, $value)
+	public function validateString($attribute, $value)
 	{
 		return is_string($value);
 	}


### PR DESCRIPTION
```
PHP Fatal error:  Access level to Frozennode\Administrator\Validator::validateString() must be public (as in class Illuminate\Validation\Validator)
```