### PR TITLE
Allow custom routes in administrator menu

### DIFF
--- a/src/Frozennode/Administrator/Config/Factory.php
+++ b/src/Frozennode/Administrator/Config/Factory.php
@@ -65,6 +65,13 @@ class Factory {
 	protected $pagePrefix = 'page.';
 
 	/**
+	 * The custom route menu prefix
+	 *
+	 * @var string
+	 */
+	protected $routePrefix = 'route.';
+
+	/**
 	 * The rules array
 	 *
 	 * @var array
@@ -124,7 +131,7 @@ class Factory {
 		$options = $this->searchMenu($name);
 
 		//return the config object if the file/array was found, or false if it wasn't
-		$config = $options ? $this->getItemConfigObject($options) : ($this->type === 'page' ? true : false);
+		$config = $options ? $this->getItemConfigObject($options) : (($this->type === 'page' || $this->type === 'route') ? true : false);
 
 		//set the primary config
 		$this->config = $primary ? $config : $this->config;
@@ -175,6 +182,11 @@ class Factory {
 		elseif (strpos($name, $this->pagePrefix) === 0)
 		{
 			return $this->type = 'page';
+		}
+		//otherwise if the name is prefixed with the page prefix
+		elseif (strpos($name, $this->routePrefix) === 0)
+		{
+			return $this->type = 'route';
 		}
 		//otherwise it's a model
 		else
@@ -241,6 +253,14 @@ class Factory {
 	{
 		return $this->pagePrefix;
 	}
+
+    /**
+     * Gets the prefix for the currently-searched item
+     */
+    public function getRoutePrefix()
+    {
+        return $this->routePrefix;
+    }
 
 	/**
 	 * Gets the prefix for the currently-searched item

--- a/src/viewComposers.php
+++ b/src/viewComposers.php
@@ -57,6 +57,7 @@ View::composer(array('administrator::partials.header'), function ($view) {
 	$view->menu = app('admin_menu')->getMenu();
 	$view->settingsPrefix = app('admin_config_factory')->getSettingsPrefix();
 	$view->pagePrefix = app('admin_config_factory')->getPagePrefix();
+	$view->routePrefix = app('admin_config_factory')->getRoutePrefix();
 	$view->configType = app()->bound('itemconfig') ? app('itemconfig')->getType() : false;
 });
 

--- a/src/views/partials/menu_item.blade.php
+++ b/src/views/partials/menu_item.blade.php
@@ -7,7 +7,8 @@
 					'item' => $subitem,
 					'key' => $k,
 					'settingsPrefix' => $settingsPrefix,
-					'pagePrefix' => $pagePrefix
+					'pagePrefix' => $pagePrefix,
+					'routePrefix' => $routePrefix,
 				))?>
 			@endforeach
 		</ul>
@@ -18,6 +19,8 @@
 			<a href="{{route('admin_settings', array(substr($key, strlen($settingsPrefix)), false))}}">{{$item}}</a>
 		@elseif (strpos($key, $pagePrefix) === 0)
 			<a href="{{route('admin_page', array(substr($key, strlen($pagePrefix)), false))}}">{{$item}}</a>
+		@elseif (strpos($key, $routePrefix) === 0)
+			<a href="{{route(substr($key, strlen($routePrefix)))}}">{{$item}}</a>
 		@else
 			<a href="{{route('admin_index', array($key), false)}}">{{$item}}</a>
 		@endif

--- a/src/views/partials/menu_item.blade.php
+++ b/src/views/partials/menu_item.blade.php
@@ -20,7 +20,7 @@
 		@elseif (strpos($key, $pagePrefix) === 0)
 			<a href="{{route('admin_page', array(substr($key, strlen($pagePrefix)), false))}}">{{$item}}</a>
 		@elseif (strpos($key, $routePrefix) === 0)
-			<a href="{{route(substr($key, strlen($routePrefix)))}}">{{$item}}</a>
+			<a href="{{route(substr($key, strlen($routePrefix)), [], false)}}">{{$item}}</a>
 		@else
 			<a href="{{route('admin_index', array($key), false)}}">{{$item}}</a>
 		@endif


### PR DESCRIPTION
I have added a feature to add custom links to administrator menu.
This way if you are using external tools like eg. Laravel Horizon, you can make them accessible for your admin panel.
Another use case would be if you need a custom controller for specific page.

The way this feature can be used is like so:

    'menu' => [
        'Models' => [
            'users',
        ],
        'Tools' => [
            'Horizon' => 'route.horizon.index',
            'EyeWitness' => 'route.eyewitness.dashboard',
            'Custom route' => 'route.my.custom.route',
        ],
    ],

assuming we have following routes defined:

    Route::get('/test', 'TestController@test')->name('my.custom.route');
    Route::get(...)->name('horizon.index'); //From horizon
    Route::get(...)->name('eyewitness.dashboard'); // From eyewitness library