### PR TITLE
adding additional catch block to handle less-specific Exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "exodusanto/administrator",
+	"name": "jkachel/laravel-admin",
 	"description": "A database interface package for Laravel (Legacy of Frozennode Laravel-Administrator)",
 	"homepage": "http://administrator.frozennode.com",
 	"keywords": ["administrator", "admin", "database", "laravel-administrator", "laravel", "cms"],

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -653,7 +653,17 @@ class AdminController extends Controller {
 			$fieldFactory = app('admin_field_factory');
 		} catch (\ReflectionException $e) {
 			return null;
+        } catch(\Exception $e) {
+		    /* TODO: this doesn't fix the issue, just keeps things that are using it from failing here
+                Once the issue is fixed, these debug logs should be removed.
+		    */
+            \Illuminate\Support\Facades\Log::debug("app('itemconfig') failed. ");
+            \Illuminate\Support\Facades\Log::debug("exception type is: " . get_class($e));
+            \Illuminate\Support\Facades\Log::debug("exception is: " . $e->getMessage());
+            \Illuminate\Support\Facades\Log::debug($e->getTraceAsString());
+            return null;
 		}
+
 		if (array_key_exists('form_request', $config->getOptions())) {
 			try {
 				$model = $config->getFilledDataModel($request, $fieldFactory->getEditFields(), $request->id);


### PR DESCRIPTION
Starting in Laravel v6, the app() call throws a BindingResolutionException rather than a ReflectionException, and doesn't get caught here, which leads to a 500 error. Since this just returned null anyway I added an additional catch block for that particular exception. This doesn't fix why this throws the exception and should probably be more specific, but works for now.