### PR TITLE
Bump `mockery/mockery`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"php": ">=7.3",
 		"laravel/framework": "8.*",
 		"ckeditor/ckeditor": "4.*",
-		"mockery/mockery": "1.4.x-dev"
+		"mockery/mockery": "^1.5 || ^1.6"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "9.x"

--- a/src/Frozennode/Administrator/Validator.php
+++ b/src/Frozennode/Administrator/Validator.php
@@ -150,6 +150,11 @@ class Validator extends \Illuminate\Validation\Validator
      */
     public function validateDirectory($attribute, $value, $parameters)
     {
+        if ($value === null)
+        {
+            return false;
+        }
+
         return is_dir($value);
     }
 
@@ -214,6 +219,11 @@ class Validator extends \Illuminate\Validation\Validator
      */
     public function validateEloquent($attribute, $value, $parameters)
     {
+        if ($value === null)
+        {
+            return false;
+        }
+
         return class_exists($value) && is_a(new $value, Model::class);
     }
 }

--- a/tests/Fields/Relationships/BelongsToTest.php
+++ b/tests/Fields/Relationships/BelongsToTest.php
@@ -3,6 +3,7 @@ namespace Frozennode\Administrator\Tests\Fields\Relationships;
 
 use Mockery as m;
 
+#[\AllowDynamicProperties]
 class BelongsToEloquentStub
 {
     public $rel;


### PR DESCRIPTION
This patch resolves #48 and fix a few deprecations, via the following changes:

- [Require released version of mockery/mockery](https://github.com/exodusanto/Laravel-Admin/commit/34e27656e3c7081aef33dc4a27f049023d6c79f2)
- [Creation of dynamic property is deprecated](https://github.com/exodusanto/Laravel-Admin/commit/3d1d3469f98651517d103e2f077063fbfb58a0b2)
- [Passing null to parameter is deprecated](https://github.com/exodusanto/Laravel-Admin/commit/322343b0cb0ece6786d0b8f3b6d219256a411b8c)

I've enabled `Allow edits by maintainers`; feel free to review the changes, provide any feedback, or make changes directly.

Thank you for your attention.